### PR TITLE
LootNotificator 2.0

### DIFF
--- a/LootNotificator/__init__.py
+++ b/LootNotificator/__init__.py
@@ -1,40 +1,59 @@
 import bl2sdk
+import unrealsdk
+from Mods import ModMenu
+from Mods.ModMenu import EnabledSaveType, Mods, ModTypes, Options,  OptionManager, RegisterMod, SDKMod, Hook
 
-class Lootbeams(bl2sdk.BL2MOD):
-    Name = "Loot Notificator"
-    Description = "Adds Special Particles to all Red Text gear. Also plays a sound. src and Reborn."
-    Author = "Juso"
-    SettingsInputs = {"Enter": "src"}
-    _Exodus = False
-    _Reborn = False
-    def SettingsInputPressed(self, name):
-        if name == "src":
-            self.Status = "src"
-            self.SettingsInputs = { 'Enter': "Reborn" }
-            self._Exodus = True
-            self._Reborn = False
-            self.Enable()
-        elif name == "Reborn":
-            self.Status = "Reborn"
-            self.SettingsInputs = { 'Enter': "Disable" }
-            self._Exodus = False
-            self._Reborn = True
-            self.Enable()
-        elif name == "Disable":
-            self.Status = "Disabled"
-            self.SettingsInputs = { 'Enter': "src" }
-            self.Enable()
-       
-    Particles = [
-                'FX_ENV_Misc.Particles.Part_Confetti',#Lowest
-                'FX_Aster_Knight.Particles.Paladin.Part_DivineShard_HitImpact', 
-                'FX_Aster_Knight.Particles.Paladin.Part_PillarOfSmite', #Middle Rarity          
-                'FX_Aster_Knight.Particles.Paladin.Part_DivineFavor',  #High Rarity
-                'FX_Aster_Knight.Particles.Paladin.Part_ConcecrateGround', #Highest Rarity     
-                'FX_Aster_ButtStallion.Particles.Part_ButtStallionSavesTheWorld' #Rainbow Rarity
-                ]       
-    
-    def ForceLoad(self):
+import os
+import json
+
+class Lootbeams(SDKMod):
+    Name: str = "Loot Notificator"
+    Version: str = "2.0"
+    Description: str = "Adds Special Particles to all Red Text gear dropped. Also plays a sound. " \
+                       "Configure which modpack you are running in the Mod Options."
+    Author: str = "Juso and SilverBeam"
+    Types: ModTypes = ModTypes.Utility
+    SaveEnabledState: EnabledSaveType = EnabledSaveType.LoadWithSettings
+
+    def __init__(self):
+        super(Lootbeams, self).__init__()
+
+        with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), "rarities.json"), "r") as f:
+            self.Rarities = json.load(f)
+
+        self.SelectedModpack = "Exodus"
+
+        self.Particles = [
+            'FX_ENV_Misc.Particles.Part_Confetti',#Lowest
+            'FX_Aster_Knight.Particles.Paladin.Part_DivineShard_HitImpact', 
+            'FX_Aster_Knight.Particles.Paladin.Part_PillarOfSmite', #Middle Rarity          
+            'FX_Aster_Knight.Particles.Paladin.Part_DivineFavor',  #High Rarity
+            'FX_Aster_Knight.Particles.Paladin.Part_ConcecrateGround', #Highest Rarity     
+            'FX_Aster_ButtStallion.Particles.Part_ButtStallionSavesTheWorld' #Rainbow Rarity
+        ]
+
+        self.EventSounds = [
+            'Ake_UI.UI_Mission.Ak_Play_UI_Mission_Reward',
+            'Ake_UI.UI_HUD.Ak_Play_UI_HUD_Chapter_Stinger'
+        ]
+
+        self.Options = [
+            OptionManager.Options.Spinner(
+                "Mod Pack",
+                f"Select which modpack you are running.",
+                StartingValue="Exodus",
+                Choices=list(self.Rarities.keys())
+            )
+        ]
+
+    def ModOptionChanged(self, option, new_value):
+        if option.Caption == "Mod Pack":
+            self.SelectedModpack = new_value   
+           
+    # This is how we know that we're in the main menu. We run the hook on the first tick of the main menu, then we unhook.
+    # This is needed due to the fact that not all packages are available to load until the MainMenu has loaded.
+    @Hook("WillowGame.FrontendGFxMovie.OnTick","ForceLoadParticles")
+    def ForceLoad(self, caller, function, params):
         bl2sdk.LoadPackage("SanctuaryAir_Dynamic")
         bl2sdk.LoadPackage("CastleKeep_FX")
         bl2sdk.LoadPackage("CastleKeep_Combat")
@@ -42,12 +61,15 @@ class Lootbeams(bl2sdk.BL2MOD):
         for Particle in self.Particles:
             temp = bl2sdk.FindObject("ParticleSystem", Particle)
             bl2sdk.KeepAlive(temp)
+        unrealsdk.RemoveHook("WillowGame.FrontendGFxMovie.OnTick","ForceLoadParticles")
 
     def GetParticle(self, index): 
-        temp = bl2sdk.FindObject("ParticleSystem", self.Particles[index])
-        print(temp)
-        return temp
+        return bl2sdk.FindObject("ParticleSystem", self.Particles[index])
 
+    def GetSound(self,index):
+        return bl2sdk.FindObject("AkEvent", self.EventSounds[index])
+
+    @Hook("WillowGame.WillowPickup.ConvertRigidBodyToFixed")
     def HandleLootBeams(self, caller, function, params):
         #We search for the EmitterPool to spawn our particles from, also we need a location.
         EmitterSpawner = bl2sdk.GetEngine().GetCurrentWorldInfo().MyEmitterPool
@@ -55,70 +77,16 @@ class Lootbeams(bl2sdk.BL2MOD):
         Rotation = (caller.Rotation.Pitch, caller.Rotation.Yaw, caller.Rotation.Roll)
         #If the RBState Position is 0 it means its not on the ground
         if caller.RBState.Position.X != 0:
-            if self._Exodus == True:
-                #These are the RarityLevels of src
-                #RareUnique
-                if caller.InventoryRarityLevel in range(11, 21):
-                    EmitterSpawner.SpawnEmitter(self.GetParticle(0), Location, Rotation)
-                    caller.PlayAkEvent(bl2sdk.FindObject("AkEvent", "Ake_UI.UI_Mission.Ak_Play_UI_Mission_Reward"))
-                #Seraph
-                elif caller.InventoryRarityLevel in range(61, 71):
-                    EmitterSpawner.SpawnEmitter(self.GetParticle(1), Location, Rotation)
-                    caller.PlayAkEvent(bl2sdk.FindObject("AkEvent", "Ake_UI.UI_Mission.Ak_Play_UI_Mission_Reward"))
-                 #Fabled/Vile
-                elif caller.InventoryRarityLevel in range(71, 86):
-                    EmitterSpawner.SpawnEmitter(self.GetParticle(2), Location, Rotation)
-                    caller.PlayAkEvent(bl2sdk.FindObject("AkEvent", "Ake_UI.UI_Mission.Ak_Play_UI_Mission_Reward"))
-                 #Legendary/Malevolent
-                elif caller.InventoryRarityLevel in range(86, 101):
-                    EmitterSpawner.SpawnEmitter(self.GetParticle(3), Location, Rotation)
-                    caller.PlayAkEvent(bl2sdk.FindObject("AkEvent", "Ake_UI.UI_HUD.Ak_Play_UI_HUD_Chapter_Stinger"))
-                #Pearlescent/Augment
-                elif caller.InventoryRarityLevel in range(101, 151) or caller.InventoryRarityLevel == 500:
-                    EmitterSpawner.SpawnEmitter(self.GetParticle(4), Location, Rotation)
-                    caller.PlayAkEvent(bl2sdk.FindObject("AkEvent", "Ake_UI.UI_HUD.Ak_Play_UI_HUD_Chapter_Stinger"))
-                #Rainbow
-                elif caller.InventoryRarityLevel in range(551, 551):
-                    EmitterSpawner.SpawnEmitter(self.GetParticle(5), Location, Rotation)
-                    caller.PlayAkEvent(bl2sdk.FindObject("AkEvent", "Ake_UI.UI_HUD.Ak_Play_UI_HUD_Chapter_Stinger"))
-
-            elif self._Reborn == True:
-                #These are the RarityLevels of Reborn
-                #Legendary and Unique Legendary
-                if caller.InventoryRarityLevel in range(5, 11) or caller.InventoryRarityLevel in range(61, 81):
-                    EmitterSpawner.SpawnEmitter(self.GetParticle(2), Location, Rotation)
-                    caller.PlayAkEvent(bl2sdk.FindObject("AkEvent", "Ake_UI.UI_HUD.Ak_Play_UI_HUD_Chapter_Stinger"))
-                #Unique Blue
-                elif caller.InventoryRarityLevel in range(41, 51):
-                    EmitterSpawner.SpawnEmitter(self.GetParticle(1), Location, Rotation)
-                    caller.PlayAkEvent(bl2sdk.FindObject("AkEvent", "Ake_UI.UI_Mission.Ak_Play_UI_Mission_Reward"))
-                 #Moxxi
-                elif caller.InventoryRarityLevel in range(51, 61):
-                    EmitterSpawner.SpawnEmitter(self.GetParticle(0), Location, Rotation)
-                    caller.PlayAkEvent(bl2sdk.FindObject("AkEvent", "Ake_UI.UI_Mission.Ak_Play_UI_Mission_Reward"))
-                 #Seraph
-                elif caller.InventoryRarityLevel in range(81, 91):
-                    EmitterSpawner.SpawnEmitter(self.GetParticle(3), Location, Rotation)
-                    caller.PlayAkEvent(bl2sdk.FindObject("AkEvent", "Ake_UI.UI_HUD.Ak_Play_UI_HUD_Chapter_Stinger"))
-                #Pearl
-                elif caller.InventoryRarityLevel in range(91, 171) or caller.InventoryRarityLevel == 500:
-                    EmitterSpawner.SpawnEmitter(self.GetParticle(4), Location, Rotation)
-                    caller.PlayAkEvent(bl2sdk.FindObject("AkEvent", "Ake_UI.UI_HUD.Ak_Play_UI_HUD_Chapter_Stinger"))
-                #Rainbow
-                elif caller.InventoryRarityLevel == 506:
-                    EmitterSpawner.SpawnEmitter(self.GetParticle(5), Location, Rotation)
-                    caller.PlayAkEvent(bl2sdk.FindObject("AkEvent", "Ake_UI.UI_HUD.Ak_Play_UI_HUD_Chapter_Stinger"))
+            for rarity in self.Rarities[self.SelectedModpack]:
+                if caller.InventoryRarityLevel in range(rarity["min_level"], rarity["max_level"] + 1):
+                    EmitterSpawner.SpawnEmitter(self.GetParticle(rarity["particle"]), Location, Rotation)
+                    caller.PlayAkEvent(self.GetSound(rarity["sound"]))
+                    break
 
     def Enable(self):
-        self.ForceLoad()
-        bl2sdk.RegisterHook("WillowGame.WillowPickup.ConvertRigidBodyToFixed", "LootBeamHook", BeamHook)
+        super().Enable()
     def Disable(self):
-        bl2sdk.RemoveHook("WillowGame.WillowPickup.ConvertRigidBodyToFixed", "LootBeamHook")
+        super().Disable()
 
-LootbeamInstance = Lootbeams()
 
-def BeamHook(caller: bl2sdk.UObject, function: bl2sdk.UFunction, params: bl2sdk.FStruct) -> bool:
-    LootbeamInstance.HandleLootBeams(caller, function, params)
-    return True
-
-bl2sdk.Mods.append(LootbeamInstance)
+unrealsdk.RegisterMod(Lootbeams())

--- a/LootNotificator/rarities.json
+++ b/LootNotificator/rarities.json
@@ -1,0 +1,127 @@
+{
+  "Vanilla/UCP": [
+    {
+      "name": "Legendary",
+      "min_level": 5,
+      "max_level": 5,
+      "particle": 2,
+      "sound": 1
+    },
+    {
+      "name": "Legendary",
+      "min_level": 7,
+      "max_level": 10,
+      "particle": 2,
+      "sound": 1
+    },
+    {
+      "name": "Seraph",
+      "min_level": 501,
+      "max_level": 501,
+      "particle": 3,
+      "sound": 1
+    },
+    {
+      "name": "Pearlescent",
+      "min_level": 500,
+      "max_level": 500,
+      "particle": 4,
+      "sound": 1
+    },
+    {
+      "name": "Effervescent",
+      "min_level": 506,
+      "max_level": 506,
+      "particle": 5,
+      "sound": 1
+    }
+  ],
+  "Exodus": [
+    {
+      "name": "Legendary",
+      "min_level": 7,
+      "max_level": 13,
+      "particle": 2,
+      "sound": 1
+    },
+    {
+      "name": "Seraph",
+      "min_level": 14,
+      "max_level": 16,
+      "particle": 3,
+      "sound": 1
+    },
+    {
+      "name": "Pearlescent",
+      "min_level": 490,
+      "max_level": 500,
+      "particle": 4,
+      "sound": 1
+    },
+    {
+      "name": "Effervescent",
+      "min_level": 506,
+      "max_level": 506,
+      "particle": 5,
+      "sound": 1
+    }
+  ],
+  "Reborn": [
+    {
+      "name": "Legendary",
+      "min_level": 5,
+      "max_level": 11,
+      "particle": 2,
+      "sound": 1
+    },
+    {
+      "name": "Unique Legendary",
+      "min_level": 61,
+      "max_level": 81,
+      "particle": 2,
+      "sound": 1
+    },
+    {
+      "name": "Unique Blue",
+      "min_level": 41,
+      "max_level": 51,
+      "particle": 1,
+      "sound": 0
+    },
+    {
+      "name": "Moxxi",
+      "min_level": 51,
+      "max_level": 61,
+      "particle": 0,
+      "sound": 0
+    },
+    {
+      "name": "Seraph",
+      "min_level": 81,
+      "max_level": 91,
+      "particle": 3,
+      "sound": 1
+    },
+    {
+      "name": "Pearlescent",
+      "min_level": 91,
+      "max_level": 170,
+      "particle": 4,
+      "sound": 1
+    },
+    {
+      "name": "Pearlescent",
+      "min_level": 500,
+      "max_level": 500,
+      "particle": 4,
+      "sound": 1
+    },
+    {
+      "name": "Effervescent",
+      "min_level": 506,
+      "max_level": 506,
+      "particle": 5,
+      "sound": 1
+    }
+  ]
+}


### PR DESCRIPTION
This PR aims to rewrite from the ground up the LootNotificator mod. The new 2.0 version brings the following advantages:
- Compliance with the newer "SDKMods"
- Additional info in the mod page
- A new user-friendly modpack selection in Options > Mods
- Settings are saved and persist on shutdown (no more need to enable the mod after each boot)
- Supported modpacks, rarities, particles and sounds are now customisable from a JSON file