### PR TITLE
BL2Eternal: Fix error logs and crash issues

### DIFF
--- a/BL2Eternal/mechanics/dashing.py
+++ b/BL2Eternal/mechanics/dashing.py
@@ -7,8 +7,7 @@ from Mods.coroutines import TickCoroutine, Time, WaitForSeconds, WaitWhile, star
 
 def _wait_for_pawn_on_ground() -> bool:
     pc = unrealsdk.GetEngine().GamePlayers[0].Actor
-    pawn = pc.Pawn
-    return pc.IsPaused() or not pawn.IsOnGroundOrShortFall()
+    return pc.IsPaused() or pc.Pawn is None or not pc.Pawn.IsOnGroundOrShortFall()
 
 
 class Dash:

--- a/BL2Eternal/mechanics/glorykills.py
+++ b/BL2Eternal/mechanics/glorykills.py
@@ -23,7 +23,7 @@ class GloryKill:
         return unrealsdk.GetEngine().GetCurrentWorldInfo().MyEmitterPool
 
     def check_glory_kill_state(self, pawn: unrealsdk.UObject) -> bool:
-        if (pawn.GetHealth() / pawn.GetMaxHealth()) < self.HEALTH_THRESHOLD:
+        if pawn.GetHealth() > 0 and pawn.GetMaxHealth() > 0 and (pawn.GetHealth() / pawn.GetMaxHealth()) < self.HEALTH_THRESHOLD:
             pawn_path_name = pawn.PathName(pawn)
             self.glory_kill_state.setdefault(pawn_path_name, 5)  # Stay 5 seconds in glory kill state
             return self.glory_kill_state[pawn_path_name] > 0  # Only first 5 seconds in glory kill state


### PR DESCRIPTION
Fix some issues causing error logs and crashes.

- [x] Fix float division by zero for glorykills
```log
ZeroDivisionError: float division by zero

At:
  E:\SteamLibrary\steamapps\common\Borderlands 2\Binaries\Win32\Mods\BL2Eternal\mechanics\glorykills.py(26): check_glory_kill_state
  E:\SteamLibrary\steamapps\common\Borderlands 2\Binaries\Win32\Mods\BL2Eternal\mechanics\glorykills.py(79): enter_glory_kill_state
  E:\SteamLibrary\steamapps\common\Borderlands 2\Binaries\Win32\Mods\BL2Eternal\mechanics\glorykills.py(138): <lambda>
```

- [x] Fix crash when one hit kill something. (https://github.com/juso40/bl2sdk_Mods/issues/37)

- [x] Fix no attribute IsOnGroundOrShortFall
Happens don't know when.
```log
AttributeError: 'NoneType' object has no attribute 'IsOnGroundOrShortFall'

At:
  E:\SteamLibrary\steamapps\common\Borderlands 2\Binaries\Win32\Mods\BL2Eternal\mechanics\dashing.py(11): _wait_for_pawn_on_ground
  E:\SteamLibrary\steamapps\common\Borderlands 2\Binaries\Win32\Mods\coroutines\loop.py(41): __call__
  E:\SteamLibrary\steamapps\common\Borderlands 2\Binaries\Win32\Mods\coroutines\loop.py(131): _tick
```